### PR TITLE
Add gdscript type warnings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,15 @@ config/name="New Game Project"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[debug]
+
+gdscript/warnings/untyped_declaration=1
+gdscript/warnings/inferred_declaration=1
+gdscript/warnings/unsafe_property_access=1
+gdscript/warnings/unsafe_method_access=1
+gdscript/warnings/unsafe_cast=1
+gdscript/warnings/unsafe_call_argument=1
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Enable GDScript type warnings to make types better and coding easier.